### PR TITLE
Container ports don't appear in Config.ExposedPorts.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -811,13 +811,6 @@ class DockerManager(object):
             for p in (self.exposed_ports or []):
                 expected_exposed_ports.add("/".join(p))
 
-            if self.port_bindings:
-                for container_port in self.port_bindings.keys():
-                    if isinstance(container_port, int):
-                        container_port = "{}/tcp".format(container_port)
-
-                    expected_exposed_ports.add(container_port)
-
             container_exposed_ports = set((container["Config"]["ExposedPorts"] or {}).keys())
             actually_exposed_ports = image_exposed_ports.union(container_exposed_ports)
 


### PR DESCRIPTION
Inferring expected exposed ports from port bindings was causing an unnecessary reload in my test playbook:

``` yaml
- name: existing running container with all the bells and whistles
  docker:
    name: running
    state: started
    image: debian:jessie
    command: sleep 1d
    expose: ["2000"]
    ports: ["3000", "3001:3002", "127.0.0.1:3002:3003", "3004:3005/tcp", "3006/tcp"]
    volumes: ["/usr:/var/wat", "/etc:/var/huh:ro", "/usr/local"]
    volumes_from: ["volumeme"]
    links: ["linkme"]
    memory_limit: 512MB
    hostname: initialhostname
    domainname: initialdomainname
    env:
      INBOTH: "yes"
      VALUECHANGE: "initialvalue"
      ONLYINITIAL: "yes"
    dns:
    - "8.8.8.8"
    stdin_open: no
    tty: no
    restart_policy: on-failure

- name: reload a container with no effects
  docker:
    name: running
    state: reloaded
    image: debian:jessie
    command: sleep 1d
    expose: ["2000"]
    ports: ["3000", "3001:3002", "127.0.0.1:3002:3003", "3004:3005/tcp", "3006/tcp"]
    volumes: ["/usr:/var/wat", "/etc:/var/huh:ro", "/usr/local"]
    volumes_from: ["volumeme"]
    links: ["linkme"]
    memory_limit: 512MB
    hostname: initialhostname
    domainname: initialdomainname
    env:
      INBOTH: "yes"
      VALUECHANGE: "initialvalue"
      ONLYINITIAL: "yes"
    dns:
    - "8.8.8.8"
    stdin_open: no
    tty: no
    restart_policy: on-failure
  register: reloaded0

- debug: var=reloaded0

- assert: { that: "not (reloaded0 | changed)" }
```

Output section:

```
ok: [localhost] => {
    "reloaded0": {
        "changed": true, 
        "reload_reasons": "exposed_ports (set([u'2000/tcp']) => set(['3003/tcp', '3006/tcp', '3000/tcp', '3005/tcp', '2000/tcp', '3002/tcp']))", 
    }
}
```
